### PR TITLE
Fix decimals

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ The vault takes heavy inspiration from the following sources:
 - [Popcorn DAO - MultiRewardStaking](https://github.com/Popcorn-Limited/contracts/blob/d029c413239735f58b0adcead11fdbe8f69a0e34/src/utils/MultiRewardStaking.sol)
 
 This is a simplified implementation that keeps only the core functionality of the vaults and removes any additional features.
+
+## WARNING
+
+** When deploying GenericStakedAppreciatingVault, make sure to mint some initial dust (at least 1e4), to avoid an inflation attack. **

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The epochs run automatically and yield is auto-compounded with hooks on the `dep
 
 ### Dev
 
-The implementation of the vault relies on an always increasing `totalAssets` value, the rate is calculated internally based on `totalAssets` per `totalSupply` which gives the exchange rate per unit of vault token. Additionally, the vault tackles inflation attacks with a decimal offset of `3` (equivalent to virtual shares offset of `1e3`).
+The implementation of the vault relies on an always increasing `totalAssets` value, the rate is calculated internally based on `totalAssets` per `totalSupply` which gives the exchange rate per unit of vault token.
 
 # Generic Multi Rewards Vault
 

--- a/contracts/staking/GenericStakedAppreciatingVault.sol
+++ b/contracts/staking/GenericStakedAppreciatingVault.sol
@@ -133,6 +133,6 @@ contract GenericStakedAppreciatingVault is ERC4626 {
     }
 
     function _decimalsOffset() internal pure override returns (uint8) {
-        return 3;
+        return 0;
     }
 }

--- a/test/ERC4626Router.t.sol
+++ b/test/ERC4626Router.t.sol
@@ -45,6 +45,6 @@ contract ERC4626RouterTest is Test {
         router.depositChained(vaults, depositAmount);
         vm.stopPrank();
 
-        assertEq(rewardsVault.balanceOf(USER1), depositAmount * 1e3);
+        assertEq(rewardsVault.balanceOf(USER1), depositAmount);
     }
 }

--- a/test/GenericStakedAppreciatingVault.t.sol
+++ b/test/GenericStakedAppreciatingVault.t.sol
@@ -26,7 +26,7 @@ contract GenericStakedAppreciatingVaultTest is Test {
         vaultDecimals = vault.decimals();
         tokenDecimals = token.decimals();
 
-        assertTrue(vaultDecimals > tokenDecimals);
+        assertTrue(vaultDecimals == tokenDecimals);
         maxError = 10 ** (vaultDecimals - tokenDecimals + 1);
 
         token.mint(DEPLOYER, 1000 * 10 ** tokenDecimals);


### PR DESCRIPTION
initially tried to add a 2e18 mint in the constructor of GenericStakedAppreciatingVault.
this caused a rather large headache in fixing the tests.
opted instead to just leave out the constructor mint, and add a comment to the README.
lmk if anyone sees a serious technical issue with this.